### PR TITLE
Fix missing imports and handle absent tags in detector

### DIFF
--- a/src/core/detector.py
+++ b/src/core/detector.py
@@ -151,12 +151,14 @@ class BAIT:
                 ).choices[0].message.content
 
                 try:
-                    state = extract_tag(response, "State").lower().strip()
+                    state = extract_tag(response, "State")
                     reasoning = extract_tag(response, "Reasoning")
 
                     if not state or not reasoning:
                         self.logger.error("Missing required tags in response")
                         continue
+
+                    state = state.lower().strip()
 
                     if state not in ["suspicious", "safe"]:
                         self.logger.error(f"Invalid state value: {state}")

--- a/src/data/base.py
+++ b/src/data/base.py
@@ -24,7 +24,7 @@ import abc
 import copy
 import os
 from fractions import Fraction
-from typing import Any, Callable, ClassVar, Collection, Dict, Iterable, Iterator
+from typing import Any, Callable, ClassVar, Collection, Dict, Iterable, Iterator, List, Optional
 from typing_extensions import NotRequired, TypedDict
 from weakref import WeakValueDictionary
 

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Optional
 from typing_extensions import TypedDict  # Python 3.10+
 
 import torch
+from transformers import PreTrainedTokenizer
+from src.config.arguments import DataArguments
 from src.data.base import CollatorBase, TokenizedDataset, left_padding
 
 class InitTokenAppendSample(TypedDict, total=True):


### PR DESCRIPTION
## Summary
- Import missing typing and transformer components in dataset and base modules
- Add defensive checks when parsing judge response tags to avoid crashes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689f45ee504483318fa2ced4ffb9649f