### PR TITLE
Fix trailing digit extraction in helpers

### DIFF
--- a/src/utils/helpers.py
+++ b/src/utils/helpers.py
@@ -33,8 +33,8 @@ def extract_number(f):
     """
     Extract the number from the filename.
     """
-    s = re.findall("\d+$",f)
-    return (int(s[0]) if s else -1,f)
+    s = re.findall(r"\d+$", f)
+    return (int(s[0]) if s else -1, f)
 
 def extract_tag(text: str, tag_name: str) -> str:
     start_tag = "<" + tag_name + ">"


### PR DESCRIPTION
## Summary
- use raw string in `extract_number` to correctly match trailing digits

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689f489b2b9483318dd4526249ce7a41